### PR TITLE
smarter .next and .prev

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -70,13 +70,17 @@
 
   Is on the last visisble item.
 
-### .prev()
+### .prev(cycle)
 
-  Show the previous item if present, or do nothing.
+  Show the previous item.
+  By default, do nothing if showing the first item.
+  If `cycle` is true and we are on the first item, display the last item.
 
-### .next()
+### .next(cycle)
 
-  Show the next item if present, or do nothing.
+  Show the next item.
+  By default, do nothing if showing the last item.
+  If `cycle` is true and we are on the last item, display the first item.
 
 ### .show(i, [ms], [options])
 

--- a/examples/grumpy.html
+++ b/examples/grumpy.html
@@ -74,6 +74,8 @@
 
     <button onclick="cats.prev()">prev</button>
     <button onclick="cats.next()">next</button>
+    <button onclick="cats.prev(true)">prev(true)</button>
+    <button onclick="cats.next(true)">next(true)</button>
     <button onclick="cats.play()">play</button>
     <button onclick="cats.stop()">stop</button>
     <button onclick="remove(0)">remove(0)</button>

--- a/index.js
+++ b/index.js
@@ -316,12 +316,7 @@ Swipe.prototype.stop = function(){
  */
 
 Swipe.prototype.cycle = function(){
-  if (this.isLast()) {
-    this.currentVisible = -1;
-    this.next();
-  } else {
-    this.next();
-  }
+  return this.next(true);
 };
 
 /**
@@ -353,7 +348,10 @@ Swipe.prototype.isLast = function(){
  * @api public
  */
 
-Swipe.prototype.prev = function(){
+Swipe.prototype.prev = function(cycle){
+  if (cycle && this.isFirst()) {
+    this.currentVisible = this.visible;
+  }
   this.show(this.currentVisible - 1);
   return this;
 };
@@ -365,7 +363,10 @@ Swipe.prototype.prev = function(){
  * @api public
  */
 
-Swipe.prototype.next = function(){
+Swipe.prototype.next = function(cycle){
+  if (cycle && this.isLast()) {
+    this.currentVisible = -1;
+  }
   this.show(this.currentVisible + 1);
   return this;
 };


### PR DESCRIPTION
Both Swipe.next and Swipe.prev take an optional `cycle` parameter.
If `cycle` is truthy we rewind slides at the beginning and end.

Swipe.cycle still works in the same way, but it's implemented as `next(true)`
Updated docs and one of the examples.
