### PR TITLE
Fix require of component/events

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var has3d = require('has-translate3d');
 var style = require('computed-style');
 var Emitter = require('emitter');
 var event = require('event');
-var events = require('events');
+var events = require('component-events');
 var min = Math.min;
 var max = Math.max;
 

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
   "browser": {
     "computed-style": "computed-style-component",
     "emitter": "component-emitter",
-    "event": "component-event",
-    "events": "component-events"
+    "event": "component-event"
   },
   "license": "MIT",
   "component": {


### PR DESCRIPTION
It was clashing with the 'events' built in in browserify...

@TooTallNate do we even want to do the `browser` mapping like we're doing for the other component deps? Why not use `component-name`?
